### PR TITLE
Add compression options for IO benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ uv pip install -r requirements.txt
 ## Running quick benchmarks
 
 ```bash
-uv pip run python src/main.py --output benchmark_data --rows 1000 10000 100000 1000000
+uv pip run python src/run_bench.py \
+  --output benchmark_data \
+  --rows 1000 10000 100000 1000000 \
+  --ipc-compression zstd \
+  --parquet-compression zstd
 ```
 
 Results are saved in the specified output directory along with a
@@ -27,7 +31,7 @@ a larger row range (up to 100M rows), saving intermediate summary data
 and publishing-ready charts.
 
 ```bash
-./run_bench.sh
+./run_bench.sh benchmark_results zstd zstd
 ```
 
 The script writes Markdown tables to `results.md` and stores CSV and PNG

--- a/run_bench.sh
+++ b/run_bench.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 OUT_DIR="${1:-benchmark_results}"
+IPC_COMP="${2:-zstd}"
+PARQUET_COMP="${3:-zstd}"
 RESULT_MD="results.md"
 
 export PYTHONPATH="$(pwd)/src"
@@ -12,7 +14,11 @@ from pathlib import Path
 from run_bench import run_benchmarks
 
 out_dir = Path("$OUT_DIR")
-results = run_benchmarks(out_dir)
+results = run_benchmarks(
+    out_dir,
+    ipc_compression="$IPC_COMP",
+    parquet_compression="$PARQUET_COMP",
+)
 results.write_csv(out_dir / "summary.csv")
 with open("$RESULT_MD", "w") as f:
     f.write(results.to_pandas().to_markdown(index=False))

--- a/src/benchmark/io_bench.py
+++ b/src/benchmark/io_bench.py
@@ -16,17 +16,27 @@ class IOBenchmark:
         func(*args, **kwargs)
         return time.perf_counter() - start
 
-    def bench_write_ipc(self, df: pl.DataFrame, filename: str) -> float:
+    def bench_write_ipc(
+        self,
+        df: pl.DataFrame,
+        filename: str,
+        compression: str | None = None,
+    ) -> float:
         path = self.base_dir / f"{filename}.feather"
-        return self._time_it(df.write_ipc, path)
+        return self._time_it(df.write_ipc, path, compression=compression)
 
     def bench_read_ipc(self, filename: str) -> float:
         path = self.base_dir / f"{filename}.feather"
         return self._time_it(pl.read_ipc, path)
 
-    def bench_write_parquet(self, df: pl.DataFrame, filename: str) -> float:
+    def bench_write_parquet(
+        self,
+        df: pl.DataFrame,
+        filename: str,
+        compression: str | None = None,
+    ) -> float:
         path = self.base_dir / f"{filename}.parquet"
-        return self._time_it(df.write_parquet, path)
+        return self._time_it(df.write_parquet, path, compression=compression)
 
     def bench_read_parquet(self, filename: str) -> float:
         path = self.base_dir / f"{filename}.parquet"


### PR DESCRIPTION
## Summary
- allow specifying compression in IOBenchmark for ipc/parquet writes
- add `--ipc-compression` and `--parquet-compression` CLI options in `run_bench.py`
- expose same parameters in `run_bench.sh`
- document new arguments in README

## Testing
- `python -m compileall -q src`
- `python src/run_bench.py --help | head -n 20`
- `bash run_bench.sh test_results zstd zstd > /tmp/runlog.txt && tail -n 5 /tmp/runlog.txt`

------
https://chatgpt.com/codex/tasks/task_e_6879d44549e88324bbba74a2acd28e16