### PR TITLE
Update README memory notes and chunked DF generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ uv pip run python src/main.py --output benchmark_data --rows 1000 10000 100000 1
 Results are saved in the specified output directory along with a
 `benchmark.png` visualization.
 
+## Memory requirements
+
+Each row consists of 50 `float32` values (~200 bytes). A 1M row DataFrame
+therefore requires roughly **200&nbsp;MB** of RAM, while a 100M row dataset would
+consume around **20&nbsp;GB**. Ensure your machine has enough memory before running
+the larger benchmarks or reduce the row sizes accordingly.
+
 ## Reproducing full results
 
 A helper script `run_bench.sh` automates running the benchmarks across

--- a/src/benchmark/data_gen.py
+++ b/src/benchmark/data_gen.py
@@ -2,7 +2,43 @@ import numpy as np
 import polars as pl
 
 
-def generate_float32_df(rows: int, cols: int = 50) -> pl.DataFrame:
-    """Generate a DataFrame with the given number of rows and float32 columns."""
-    data = {f"col_{i}": np.random.rand(rows).astype(np.float32) for i in range(cols)}
-    return pl.DataFrame(data)
+def generate_float32_df(
+    rows: int,
+    cols: int = 50,
+    *,
+    chunk_size: int | None = None,
+    lazy: bool = False,
+) -> pl.DataFrame | pl.LazyFrame:
+    """Generate a DataFrame with the given number of rows and float32 columns.
+
+    Parameters
+    ----------
+    rows:
+        Number of rows in the resulting frame.
+    cols:
+        Number of `float32` columns to create.
+    chunk_size:
+        Optional chunk size used when ``rows`` is very large. If provided, data
+        is generated in smaller pieces and concatenated which can help reduce
+        peak memory usage during creation.
+    lazy:
+        Return a ``LazyFrame`` instead of a ``DataFrame``.
+    """
+
+    if chunk_size is None or rows <= chunk_size:
+        data = {
+            f"col_{i}": np.random.rand(rows).astype(np.float32) for i in range(cols)
+        }
+        df = pl.DataFrame(data)
+    else:
+        dfs = []
+        for start in range(0, rows, chunk_size):
+            end = min(start + chunk_size, rows)
+            data = {
+                f"col_{i}": np.random.rand(end - start).astype(np.float32)
+                for i in range(cols)
+            }
+            dfs.append(pl.DataFrame(data))
+        df = pl.concat(dfs, how="vertical")
+
+    return df.lazy() if lazy else df


### PR DESCRIPTION
## Summary
- document RAM requirements for large row counts
- support generating DataFrames in chunks or lazily

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `PYTHONPATH=src python - <<'PY'
from benchmark.data_gen import generate_float32_df
print(generate_float32_df(5))
print(generate_float32_df(5, chunk_size=2))
print(type(generate_float32_df(5, lazy=True)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6879d44d8cf883249b62e58c267ee6c7